### PR TITLE
fix: large bbox

### DIFF
--- a/src/tiles/tiles.ts
+++ b/src/tiles/tiles.ts
@@ -51,7 +51,7 @@ function tileEffectiveWidth(zoom: Zoom, referenceTileGrid: TileGrid = TILEGRID_W
 
 function polygonToTiles(polygon: Polygon, zoom: Zoom, referenceTileGrid: TileGrid = TILEGRID_WORLD_CRS84): TileRange[] {
   const boundingBox = geometryToBoundingBox(polygon);
-  const minimalZoom = findMinimalZoom(boundingBox, referenceTileGrid);
+  const minimalZoom = findMinimalZoom(boundingBox, referenceTileGrid) ?? 0;
   const tileRange = boundingBoxToTileRange(boundingBox, Math.min(minimalZoom, zoom), 1, referenceTileGrid);
   return polygonToTileRanges(polygon, tileRange, zoom, referenceTileGrid);
 }
@@ -285,9 +285,9 @@ export function expandBoundingBoxToTileGrid(boundingBox: BoundingBox, zoom: Zoom
  * Find the minimal zoom where a bounding box can be contained in a single tile (the tile may still intersect a tile boundary)
  * @param boundingBox bounding box
  * @param referenceTileGrid tile grid
- * @returns minimal zoom that may contain the bounding box in a single tile
+ * @returns minimal zoom that may contain the bounding box in a single tile or null if it could not be contained in any zoom level
  */
-export function findMinimalZoom(boundingBox: BoundingBox, referenceTileGrid: TileGrid = TILEGRID_WORLD_CRS84): Zoom {
+export function findMinimalZoom(boundingBox: BoundingBox, referenceTileGrid: TileGrid = TILEGRID_WORLD_CRS84): Zoom | null {
   validateBoundingBox(boundingBox);
   validateTileGrid(referenceTileGrid);
   validateBoundingBoxByGrid(boundingBox, referenceTileGrid);
@@ -303,7 +303,8 @@ export function findMinimalZoom(boundingBox: BoundingBox, referenceTileGrid: Til
     Math.log2((referenceTileGrid.boundingBox.max.lat - referenceTileGrid.boundingBox.min.lat) / (referenceTileGrid.numberOfMinLevelTilesY * dy))
   );
 
-  return Math.min(minimalXZoom, minimalYZoom);
+  const minimalZoom = Math.min(minimalXZoom, minimalYZoom);
+  return minimalZoom >= 0 ? minimalZoom : null;
 }
 
 /**

--- a/tests/tiles/tiles.spec.ts
+++ b/tests/tiles/tiles.spec.ts
@@ -1,9 +1,9 @@
 import {
   boundingBoxToTileRange,
   expandBoundingBoxToTileGrid,
-  findMinimalZoom,
   geometryToTiles,
   geoPointZoomToTile,
+  minimalBoundingTile,
   tileToBoundingBox,
   tileToTileRange,
   zoomShift,
@@ -590,34 +590,66 @@ describe('Snap a bounding box to tile grid', () => {
   });
 });
 
-describe('Find minimal zoom that can contain bounding box in one tile', () => {
-  it('should return correct zoom starting at zoom 2 and moving to 1', () => {
+describe('#minimalBoundingTile', () => {
+  it('should return correct tile starting lookup at zoom 1 and moving to 0', () => {
     const boundingBox = new BoundingBox(-135, -45, -45, 45);
-    const minimalZoom = findMinimalZoom(boundingBox);
-    const expectedZoom = 1;
-    expect(minimalZoom).toEqual(expectedZoom);
+    const expectedTile = new Tile(0, 0, 0, 1);
+
+    const tile = minimalBoundingTile(boundingBox);
+
+    expect(tile).toStrictEqual(expectedTile);
   });
 
-  it('should return correct zoom', () => {
+  it('should return correct tile starting at lookup at zoom 2 and moving to 0', () => {
+    const boundingBox = new BoundingBox(160, -5, 170, 5);
+    const expectedTile = new Tile(1, 0, 0, 1);
+
+    const tile = minimalBoundingTile(boundingBox);
+
+    expect(tile).toStrictEqual(expectedTile);
+  });
+
+  it('should return correct tile', () => {
     const boundingBox = new BoundingBox(10, 10, 30, 30);
-    const minimalZoom = findMinimalZoom(boundingBox);
-    const expectedZoom = 3;
-    expect(minimalZoom).toEqual(expectedZoom);
+    const expectedTile = new Tile(4, 1, 2, 1);
+
+    const tile = minimalBoundingTile(boundingBox);
+
+    expect(tile).toStrictEqual(expectedTile);
   });
 
-  it('Small bounding box located on the edge of minimal tiles should go one level up', () => {
-    const boundingBox = new BoundingBox(-100, -60, -45, -5);
-    const minimalZoom = findMinimalZoom(boundingBox);
-    const expectedZoom = 1;
-    expect(minimalZoom).toEqual(expectedZoom);
+  it("should return correct tile even if the bounding box is touching the tile's edge", () => {
+    const boundingBox = new BoundingBox(25, 10, 45, 30);
+    const expectedTile = new Tile(4, 1, 2, 1);
+
+    const tile = minimalBoundingTile(boundingBox);
+
+    expect(tile).toStrictEqual(expectedTile);
+  });
+
+  it('bounding box located on the edge of a tile grid should go one zoom level up', () => {
+    const boundingBox = new BoundingBox(45, 10, 65, 30);
+    const expectedTile = new Tile(5, 1, 2, 1);
+
+    const tile = minimalBoundingTile(boundingBox);
+
+    expect(tile).toStrictEqual(expectedTile);
   });
 
   it('should return null if bounding box could not be contained in any zoom level', () => {
     const boundingBox = new BoundingBox(-170, -60, 170, -5);
 
-    const minimalZoom = findMinimalZoom(boundingBox);
+    const tile = minimalBoundingTile(boundingBox);
 
-    expect(minimalZoom).toBeNull();
+    expect(tile).toBeNull();
+  });
+
+  it('should return null if bounding box could not be contained in any zoom level for small bounding box intersecting tile grid at zoom 0', () => {
+    const boundingBox = new BoundingBox(-1, -1, 1, 1);
+
+    const tile = minimalBoundingTile(boundingBox);
+
+    expect(tile).toBeNull();
   });
 });
 

--- a/tests/tiles/tiles.spec.ts
+++ b/tests/tiles/tiles.spec.ts
@@ -611,6 +611,14 @@ describe('Find minimal zoom that can contain bounding box in one tile', () => {
     const expectedZoom = 1;
     expect(minimalZoom).toEqual(expectedZoom);
   });
+
+  it('should return null if bounding box could not be contained in any zoom level', () => {
+    const boundingBox = new BoundingBox(-170, -60, 170, -5);
+
+    const minimalZoom = findMinimalZoom(boundingBox);
+
+    expect(minimalZoom).toBeNull();
+  });
 });
 
 describe('#geometryToTiles', () => {

--- a/tests/tiles/tiles.spec.ts
+++ b/tests/tiles/tiles.spec.ts
@@ -590,63 +590,53 @@ describe('Snap a bounding box to tile grid', () => {
   });
 });
 
+const goodMinimalBoundingTileTests = [
+  {
+    testCaseName: 'starting lookup at zoom 1 and moving to 0',
+    boundingBox: new BoundingBox(-135, -45, -45, 45),
+    expectedTile: new Tile(0, 0, 0, 1),
+  },
+  {
+    testCaseName: 'starting lookup at zoom 2 and moving to 0',
+    boundingBox: new BoundingBox(160, -5, 170, 5),
+    expectedTile: new Tile(1, 0, 0, 1),
+  },
+  {
+    testCaseName: '',
+    boundingBox: new BoundingBox(10, 10, 30, 30),
+    expectedTile: new Tile(4, 1, 2, 1),
+  },
+  {
+    testCaseName: "even if the bounding box is touching the tile's edge",
+    boundingBox: new BoundingBox(25, 10, 45, 30),
+    expectedTile: new Tile(4, 1, 2, 1),
+  },
+  {
+    testCaseName: 'when the bounding box is located on the edge of a tile grid, should go one zoom level up',
+    boundingBox: new BoundingBox(45, 10, 65, 30),
+    expectedTile: new Tile(2, 0, 1, 1),
+  },
+];
+
+const badMinimalBoundingTileTests = [
+  {
+    testCaseName: 'if bounding box could not be contained in any zoom level for large bounding box intersecting tile grid at zoom 0',
+    boundingBox: new BoundingBox(-170, -60, 170, -5),
+  },
+  {
+    testCaseName: 'if bounding box could not be contained in any zoom level for small bounding box intersecting tile grid at zoom 0',
+    boundingBox: new BoundingBox(-1, -1, 1, 1),
+  },
+];
+
 describe('#minimalBoundingTile', () => {
-  it('should return correct tile starting lookup at zoom 1 and moving to 0', () => {
-    const boundingBox = new BoundingBox(-135, -45, -45, 45);
-    const expectedTile = new Tile(0, 0, 0, 1);
-
+  it.each(goodMinimalBoundingTileTests)('should return minimal bounding tile $testCaseName', ({ boundingBox, expectedTile }) => {
     const tile = minimalBoundingTile(boundingBox);
 
     expect(tile).toStrictEqual(expectedTile);
   });
 
-  it('should return correct tile starting at lookup at zoom 2 and moving to 0', () => {
-    const boundingBox = new BoundingBox(160, -5, 170, 5);
-    const expectedTile = new Tile(1, 0, 0, 1);
-
-    const tile = minimalBoundingTile(boundingBox);
-
-    expect(tile).toStrictEqual(expectedTile);
-  });
-
-  it('should return correct tile', () => {
-    const boundingBox = new BoundingBox(10, 10, 30, 30);
-    const expectedTile = new Tile(4, 1, 2, 1);
-
-    const tile = minimalBoundingTile(boundingBox);
-
-    expect(tile).toStrictEqual(expectedTile);
-  });
-
-  it("should return correct tile even if the bounding box is touching the tile's edge", () => {
-    const boundingBox = new BoundingBox(25, 10, 45, 30);
-    const expectedTile = new Tile(4, 1, 2, 1);
-
-    const tile = minimalBoundingTile(boundingBox);
-
-    expect(tile).toStrictEqual(expectedTile);
-  });
-
-  it('bounding box located on the edge of a tile grid should go one zoom level up', () => {
-    const boundingBox = new BoundingBox(45, 10, 65, 30);
-    const expectedTile = new Tile(5, 1, 2, 1);
-
-    const tile = minimalBoundingTile(boundingBox);
-
-    expect(tile).toStrictEqual(expectedTile);
-  });
-
-  it('should return null if bounding box could not be contained in any zoom level', () => {
-    const boundingBox = new BoundingBox(-170, -60, 170, -5);
-
-    const tile = minimalBoundingTile(boundingBox);
-
-    expect(tile).toBeNull();
-  });
-
-  it('should return null if bounding box could not be contained in any zoom level for small bounding box intersecting tile grid at zoom 0', () => {
-    const boundingBox = new BoundingBox(-1, -1, 1, 1);
-
+  it.each(badMinimalBoundingTileTests)('should return null $testCaseName', ({ boundingBox }) => {
     const tile = minimalBoundingTile(boundingBox);
 
     expect(tile).toBeNull();


### PR DESCRIPTION
fixes a bug, in `findMinimalZoom`, once a bbox is given with one of it's axes larger than the tile size in the corresponding axis at the firts zoom level (0)